### PR TITLE
bug fix in subtitleContainer

### DIFF
--- a/css/detections.css
+++ b/css/detections.css
@@ -4,7 +4,7 @@
 }
 #subtitlesContainer{
     width:100%;
-    height:30px;
+    /*height:30px;*/
 }
 #subtitles{
     font-size:14px;


### PR DESCRIPTION
Adjusted height of the ```subtitlesContainer``` in order to avoid overlap of controllers on to the subtitles.